### PR TITLE
Update infoblox_ipam_agent

### DIFF
--- a/networking_infoblox/neutron/cmd/eventlet/infoblox_ipam_agent.py
+++ b/networking_infoblox/neutron/cmd/eventlet/infoblox_ipam_agent.py
@@ -36,6 +36,7 @@ def register_options():
 
 
 def main():
+    common_config.register_common_config_options()
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
     register_options()

--- a/networking_infoblox/tools/create_ea_defs.py
+++ b/networking_infoblox/tools/create_ea_defs.py
@@ -64,6 +64,7 @@ cfg.CONF(args=sys.argv[1:])
 
 
 def main():
+    common_config.register_common_config_options()
     cfg.CONF(args=sys.argv[1:],
              default_config_files=['/etc/neutron/neutron.conf'])
     common_config.setup_logging()

--- a/networking_infoblox/tools/infoblox_grid_sync.py
+++ b/networking_infoblox/tools/infoblox_grid_sync.py
@@ -34,6 +34,7 @@ def register_options():
 
 
 def main():
+    common_config.register_common_config_options()
     common_config.init(sys.argv[1:])
     common_config.setup_logging()
     register_options()

--- a/networking_infoblox/tools/sync_neutron_to_infoblox.py
+++ b/networking_infoblox/tools/sync_neutron_to_infoblox.py
@@ -68,6 +68,7 @@ DEFAULT_CONFIG_FILES = ['/etc/neutron/neutron.conf']
 
 
 def main():
+    common_config.register_common_config_options()
     cfg.CONF(args=sys.argv[1:],
              default_config_files=DEFAULT_CONFIG_FILES)
     common_config.setup_logging()


### PR DESCRIPTION
Changes to support Zed release

Zed releases require the following approach [1] for importing config options. Without this change the plugin fails to load and simply errors out.

[1] https://review.opendev.org/c/openstack/neutron/+/837392